### PR TITLE
Fixed $timestamp in hmacAuthorizationToken()

### DIFF
--- a/payeezy_php/example/src/Payeezy.php
+++ b/payeezy_php/example/src/Payeezy.php
@@ -391,7 +391,7 @@ class Payeezy
 
     $nonce = strval(hexdec(bin2hex(openssl_random_pseudo_bytes(4, $cstrong))));
 
-    $timestamp = strval(time()*1000); //time stamp in milli seconds
+    $timestamp = sprintf("%.0f", microtime(true) * 1000);
 
     $data = self::$apiKey . $nonce . $timestamp . self::$merchantToken . $payload;
 

--- a/payeezy_php/example/src/Payeezy.php
+++ b/payeezy_php/example/src/Payeezy.php
@@ -391,7 +391,7 @@ class Payeezy
 
     $nonce = strval(hexdec(bin2hex(openssl_random_pseudo_bytes(4, $cstrong))));
 
-    $timestamp = sprintf("%.0f", microtime(true) * 1000);
+    $timestamp = sprintf('%.0f', array_sum(explode(' ', microtime())) * 1000);
 
     $data = self::$apiKey . $nonce . $timestamp . self::$merchantToken . $payload;
 

--- a/payeezy_php/example/src/Payeezy.php
+++ b/payeezy_php/example/src/Payeezy.php
@@ -391,7 +391,7 @@ class Payeezy
 
     $nonce = strval(hexdec(bin2hex(openssl_random_pseudo_bytes(4, $cstrong))));
 
-    $timestamp = sprintf('%.0f', array_sum(explode(' ', microtime())) * 1000);
+    $timestamp = sprintf('%.0f', array_sum(explode(' ', microtime())) * 1000);	// timestamp in milliseconds
 
     $data = self::$apiKey . $nonce . $timestamp . self::$merchantToken . $payload;
 


### PR DESCRIPTION
Old timestamp method used time() * 1000 [which on many systems is a float (and only accurate to the second)] & converting that into a string, resulting in incorrect values:

```php
$timestamp = strval(time()*1000); // example: '1.45952654E+12'
```
New method creates accurate, correct values:

```php
$timestamp = sprintf('%.0f', array_sum(explode(' ', microtime())) * 1000); // example: '1459526540161'
```