### PR TITLE
bug fix when checking transactionType value

### DIFF
--- a/payeezy_python/example/payeezy/api_methods.py
+++ b/payeezy_python/example/payeezy/api_methods.py
@@ -95,7 +95,7 @@ class Payeezy(object):
 		if description is None:
 			description = transactionType+'transaction for amount: '+amount
 
-		if (transactionType == ('authorize' or 'purchase')): 
+		if transactionType in ['authorize', 'purchase']: 
 
 			if card_number is None:
 				raise ValueError, 'card number cannot be nil'


### PR DESCRIPTION
I believe that the line I changed had to have been a mistake.
`('authorize' or 'purchase')` evaluates to `'authorize'` in python

so the line
```python
if (transactionType == ('authorize' or 'purchase')):
```
is effectively just
```python
if transactionType == 'authorize':
```